### PR TITLE
extern "C" in public headers

### DIFF
--- a/include/pogona/logger.h
+++ b/include/pogona/logger.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <pogona/types.h>
 
 typedef enum {
@@ -28,3 +32,7 @@ void loggerLog(LoggerLevel level, const char* sourceFile, usize sourceLine, cons
 #define LOGGER_WARN(...) loggerLog(LOGGER_WARNING, __FILE__, __LINE__, __VA_ARGS__)
 #define LOGGER_ERROR(...) loggerLog(LOGGER_ERROR, __FILE__, __LINE__, __VA_ARGS__)
 #define LOGGER_FATAL(...) loggerLog(LOGGER_FATAL, __FILE__, __LINE__, __VA_ARGS__)
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/pogona/math/linear.h
+++ b/include/pogona/math/linear.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <pogona/types.h>
 
 #define DEFINE_TYPE(type)                             \
@@ -68,3 +72,7 @@ DEFINE_TYPE(f32);
 DEFINE_TYPE(f64);
 
 #undef DEFINE_TYPE
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/pogona/pogona.h
+++ b/include/pogona/pogona.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* for use only in applications */
 
 #include <pogona/logger.h>
@@ -14,3 +18,7 @@
 #include <pogona/types.h>
 #include <pogona/vector.h>
 #include <pogona/window.h>
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/pogona/renderer.h
+++ b/include/pogona/renderer.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <pogona/types.h>
 #include <pogona/window.h>
 
@@ -31,3 +35,7 @@ typedef struct {
 i32 rendererCreate(Renderer* self, RendererApiType apiType, Window* window);
 i32 rendererDraw(Renderer* self);
 i32 rendererDestroy(Renderer* self);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/pogona/types.h
+++ b/include/pogona/types.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdbool.h> // don't remove this import!
 #include <stddef.h>
 #include <stdint.h>
@@ -31,3 +35,7 @@ typedef ssize_t isize;
 
 typedef float f32;
 typedef double f64;
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/pogona/vector.h
+++ b/include/pogona/vector.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <pogona/types.h>
 
 #define VECTOR(T)   \
@@ -50,3 +54,7 @@ typedef VECTOR(isize) ISizeVector;
 
 typedef VECTOR(void*) VoidVector;
 typedef VECTOR(const char*) StringVector;
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/pogona/window.h
+++ b/include/pogona/window.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <pogona/math/linear.h>
 
 typedef void* WindowApi;
@@ -34,3 +38,7 @@ i32 windowSetTitle(Window* self, const char* title);
 i32 windowIsClosed(Window* self, bool* flag);
 i32 windowPollEvents(Window* self);
 i32 windowDestroy(Window* self);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
C++ mangles names for function overloading, and to make pogona work with C++ code we need to do `extern "C" {...}` if the file we're being included to is C++.

This closes #15.